### PR TITLE
if not enough data, break early

### DIFF
--- a/firmware/MDNS.cpp
+++ b/firmware/MDNS.cpp
@@ -84,6 +84,7 @@ int MDNS::processQueries() {
             if ((flags & 0x8000) == 0) {
                 while (qdcount-- > 0) {
                     int8_t matchedName = matcher->match(buffer);
+                    if (buffer->available() < 4) break;
 
                     uint16_t type = buffer->readUInt16();
                     uint16_t cls = buffer->readUInt16();


### PR DESCRIPTION
When using this on a noisy network, the spark was crashing constantly. 

In a quick review,  I found the potential for a out of bounds read (buffer overflow).

The original code makes the assumption the packet is compliant and has enough data.
This fix addresses that.
